### PR TITLE
Episode 03

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,49 @@ const heading = React.createElement(
   React.createElement('h2', {id: 'sibling'}, 'I am h2 Sibling2')]
 )
 
+
+
+
+
+//JSX - Not HTML in JS, but HTML/XML-like syntax
+// This code is transpiled before it reaches jS engine. => by parcel through a package called Babel.
+// JSX => Babel transpiles it to React.createElement => ReactElement-JS Object => HTML Element(render)
+const jsxHeading = <h1 className="heading">Hello World from JSX</h1>
+
+
+
+
+
+
+
+
+// React Functional Component
+const HeadingComponent = () => {
+  return <h1 className="heading">Hello World from Functional Component</h1>
+}
+
+// React Functional Component
+const SubHeading = () => <h3 className="subheading">This is a Subheading Functional component</h3>
+
+// React Element
+const title = <p className='title'>This is a Title React Element</p>
+
+// Component Composition => composing components into a component.
+const Container = () => {
+  return (
+    <div className="container">
+      <HeadingComponent />
+      <SubHeading />
+      {title}
+    </div>
+  )
+}
+
+
+
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
-root.render(heading);
+// root.render(heading);    //Render React Element
+// root.render(jsxHeading); //Render JSX Element
+root.render(<Container />);  // Render React Functional Component

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@
 - Code Splitting
 - Differential Bundling => to support older browsers
 - Tree Shaking - remove unused code
+
+# Episode 03
+
+- Added scripts to run and build
+- Use JSX instead of React.createElement
+- Understood the use of Babel
+- JSX behind the scenes works same as React.createElement
+- React Functional Components => Components are independent and reusable bits of code => A function that returns a JSX element is called React Functional Component.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "React Practice",
   "scripts": {
+    "start": "parcel index.html",
+    "build": "parcel build index.html",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
- Added scripts to run and build
- Use JSX instead of React.createElement
- Understood the use of Babel
- JSX behind the scenes works same as React.createElement
- React Functional Components => Components are independent and reusable bits of code => A function that returns a JSX element is called React Functional Component.